### PR TITLE
Adicionado correções no relacionamento Post e Tag

### DIFF
--- a/Modulo 3/Blog/Data/Mappings/PostMap.cs
+++ b/Modulo 3/Blog/Data/Mappings/PostMap.cs
@@ -54,17 +54,17 @@ namespace Blog.Data.Mappings
                 .WithMany(x => x.Posts)
                 .UsingEntity<Dictionary<string, object>>(
                     "PostTag",
-                    post => post
-                        .HasOne<Tag>()
-                        .WithMany()
-                        .HasForeignKey("PostId")
-                        .HasConstraintName("FK_PostRole_PostId")
-                        .OnDelete(DeleteBehavior.Cascade),
                     tag => tag
-                        .HasOne<Post>()
+                        .HasOne<Tag>()
                         .WithMany()
                         .HasForeignKey("TagId")
                         .HasConstraintName("FK_PostTag_TagId")
+                        .OnDelete(DeleteBehavior.Cascade),
+                    post => post
+                        .HasOne<Post>()
+                        .WithMany()
+                        .HasForeignKey("PostId")
+                        .HasConstraintName("FK_PostTag_PostId")
                         .OnDelete(DeleteBehavior.Cascade));
         }
     }


### PR DESCRIPTION
Adicionado correções no mapeamento entre o relacionamento das tabelas Post e Tag.

Atualmente na tabela PostTag, o "PostId" está como ForeignKey de "Id" da tabela Tag
e "TagId" está como ForeignKey de "Id"da tabela Post

Isso está causando problema na execução do script do módulo 3.